### PR TITLE
fix: improve request body format to fix 400 Bad Request

### DIFF
--- a/entities.go
+++ b/entities.go
@@ -32,6 +32,10 @@ func WithAPIKey(apiKey string) ClientOption {
 	}
 }
 
+type ResponseFormat struct {
+	Type string `json:"type,omitempty"`
+}
+
 type requestBody struct {
 	// Messages represents a slice of Message structures for the chat completion request.
 	Messages []Message `json:"messages"`
@@ -40,9 +44,7 @@ type requestBody struct {
 	// MaxTokens sets the maximum number of tokens to generate.
 	MaxTokens int `json:"max_tokens"`
 	// ResponseFormat specifies the format of the response.
-	ResponseFormat struct {
-		Type string `json:"type,omitempty"`
-	} `json:"response_format,omitempty"`
+	ResponseFormat *ResponseFormat `json:"response_format,omitempty"`
 	// Seed sets the seed for the random number generator.
 	Seed int `json:"seed,omitempty"`
 	// Stream indicates whether to stream the response.


### PR DESCRIPTION
Make ResponseFormat a pointer to prevent empty response_format objects

## Changes
- Created a separate ResponseFormat struct
- Changed ResponseFormat field in requestBody to be a pointer (*ResponseFormat)
- This allows the field to be set to nil, which properly omits it from JSON output

## Benefits
- Prevents sending empty `response_format: {}` objects to the API
- Resolves 400 Bad Request errors when the response_format.type is missing
- Maintains backward compatibility while fixing issue #3

When ResponseFormat is nil, the field is now completely omitted from requests instead of being serialized as an empty object, which the API rejects.